### PR TITLE
add user object to backup/restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ of the following objects.
  * Syncable Objects
  * File formats
  * File field metadata
+ * Users
 
 # Version
 
@@ -84,6 +85,8 @@ The following flags are available to help run this tool.
  level to be skipped. This means that if a table no longer exists in a database then instead
  of the whole setup failing, that table will be skipped. Similar to columns missing from tables.
  This flag is only used in setup mode.
+ * `-R` when running in backup mode, redacts user information (first name, last name, email address)
+ and replaces with `REDACTED`.
 
  The `-f` flag is always required and one and only one of `-s` or `-b` must be provided.
 
@@ -170,13 +173,13 @@ to restore a masking application to the configuration specified in the `yaml` fi
 
 # Password Limitations
 
-One limitation of the API is that it does not return database or SFTP server passwords.
+One limitation of the API is that it does not return database, user, or SFTP server passwords.
 This is done for security purposes. This means the backup file does not contain the
-database or SFTP server passwords. In order to completely restore from a backup file, you
+database, user, or SFTP server passwords. In order to completely restore from a backup file, you
 must do the following.
 
-Manually open up the backup file and fill in all password fields. They are
-tagged with `DATABASE_PASSWORD` and `SFTP_PASSWORD` so that they can be easily identified.
+Manually open up the backup file and fill in all password fields. They are tagged with
+`DATABASE_PASSWORD`, `USER_PASSWORD` and `SFTP_PASSWORD` so that they can be easily identified.
 
 # File Masking
 

--- a/generator/src/main/resources/endpointDefinitions/NonAdminProperties.yaml
+++ b/generator/src/main/resources/endpointDefinitions/NonAdminProperties.yaml
@@ -1,0 +1,10 @@
+className: [non, Admin, Properties]
+generatePost: false
+generatePut: false
+generateGet: false
+memberVariables:
+  - name: roleId
+    type: Integer
+  - name: environmentIds
+    type: List
+    listType: Integer

--- a/generator/src/main/resources/endpointDefinitions/User.yaml
+++ b/generator/src/main/resources/endpointDefinitions/User.yaml
@@ -1,0 +1,26 @@
+className: [user]
+endpointPath: users
+nameField: UserName
+idField: UserId
+generatePut: false
+memberVariables:
+  - name: userId
+    type: Integer
+  - name: userName
+    type: String
+  - name: password
+    type: String
+  - name: firstName
+    type: String
+  - name: lastName
+    type: String
+  - name: email
+    type: String
+  - name: isAdmin
+    type: Boolean
+  - name: showWelcome
+    type: Boolean
+  - name: isLocked
+    type: Boolean
+  - name: nonAdminProperties
+    type: NonAdminProperties

--- a/src/main/java/com/delphix/masking/initializer/ApplicationFlags.java
+++ b/src/main/java/com/delphix/masking/initializer/ApplicationFlags.java
@@ -39,6 +39,7 @@ public class ApplicationFlags {
     private static final String MASKED_COLUMN_OPTION = "m";
     private static final String LOG_LEVEL_OPTION = "l";
     private static final String IGNORE_ERRORS = "i";
+    private static final String REDACT_USER_INFO = "R";
     private static final String AUTHTOKEN_OPTION = "t";
 
     private static final String MASKING_USER = "MASKING_USER";
@@ -64,6 +65,8 @@ public class ApplicationFlags {
     Boolean overwrite;
     @Getter
     Boolean global;
+    @Getter
+    Boolean redactUserInfo;
     @Getter
     Boolean sync;
     @Getter
@@ -100,6 +103,7 @@ public class ApplicationFlags {
         options.addOption(MASKED_COLUMN_OPTION, false, "Only backup masked columns");
         options.addOption(LOG_LEVEL_OPTION, true, "Level of logging to use");
         options.addOption(IGNORE_ERRORS, false, "Specifies that errors should be ignored");
+        options.addOption(REDACT_USER_INFO, false, "Specifies that user info should be redacted");
         options.addOption(AUTHTOKEN_OPTION, true, "Authorization token");
 
         // Read in the command line options and parse them
@@ -190,6 +194,7 @@ public class ApplicationFlags {
              */
             global = commandLine.hasOption(GLOBAL_OPTION);
             sync = commandLine.hasOption(ENGINE_SYNC_OPTION);
+            redactUserInfo = commandLine.hasOption(REDACT_USER_INFO);
 
         } else {
             logger.trace("Parsing flags for setup mode");

--- a/src/main/java/com/delphix/masking/initializer/maskingApi/SetupDriver.java
+++ b/src/main/java/com/delphix/masking/initializer/maskingApi/SetupDriver.java
@@ -1,5 +1,23 @@
 package com.delphix.masking.initializer.maskingApi;
 
+import static com.delphix.masking.initializer.Constants.BASE_FILE;
+import static com.delphix.masking.initializer.Constants.JSON_EXTENSION;
+import static com.delphix.masking.initializer.Constants.MASKING;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.delphix.masking.initializer.ApplicationFlags;
 import com.delphix.masking.initializer.Utils;
 import com.delphix.masking.initializer.exception.ApiCallException;
@@ -27,6 +45,7 @@ import com.delphix.masking.initializer.maskingApi.endpointCaller.PostProfileExpr
 import com.delphix.masking.initializer.maskingApi.endpointCaller.PostProfileSet;
 import com.delphix.masking.initializer.maskingApi.endpointCaller.PostProfilingJob;
 import com.delphix.masking.initializer.maskingApi.endpointCaller.PostTableMetadata;
+import com.delphix.masking.initializer.maskingApi.endpointCaller.PostUser;
 import com.delphix.masking.initializer.maskingApi.endpointCaller.PutColumnMetadata;
 import com.delphix.masking.initializer.maskingApi.endpointCaller.PutFileFieldMetadata;
 import com.delphix.masking.initializer.pojo.Application;
@@ -47,23 +66,7 @@ import com.delphix.masking.initializer.pojo.ProfileExpression;
 import com.delphix.masking.initializer.pojo.ProfileSet;
 import com.delphix.masking.initializer.pojo.ProfilingJob;
 import com.delphix.masking.initializer.pojo.TableMetadata;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.delphix.masking.initializer.Constants.BASE_FILE;
-import static com.delphix.masking.initializer.Constants.JSON_EXTENSION;
-import static com.delphix.masking.initializer.Constants.MASKING;
+import com.delphix.masking.initializer.pojo.User;
 
 public class SetupDriver {
 
@@ -196,6 +199,10 @@ public class SetupDriver {
                 handleDomains(maskingSetup.getDomains());
             }
 
+            if (maskingSetup.getUsers() != null) {
+                handleUsers(maskingSetup.getUsers());
+            }
+
             Map<String, Integer> profileExpressionMap = null;
             if (maskingSetup.getProfileExpressions() != null) {
                 profileExpressionMap = handleProfilerExpressions(maskingSetup.getProfileExpressions());
@@ -310,6 +317,12 @@ public class SetupDriver {
     private void handleDomains(List<Domain> domains) throws ApiCallException {
         for (Domain domain : domains) {
             apiCallDriver.makePostCall(new PostDomain(domain));
+        }
+    }
+
+    private void handleUsers(List<User> users) throws ApiCallException {
+        for (User user : users) {
+            apiCallDriver.makePostCall(new PostUser(user));
         }
     }
 

--- a/src/main/java/com/delphix/masking/initializer/pojo/MaskingSetup.java
+++ b/src/main/java/com/delphix/masking/initializer/pojo/MaskingSetup.java
@@ -25,6 +25,7 @@ public class MaskingSetup {
     private List<Domain> domains;
     private List<ExportObject> exportObjects;
     private List<String> exportObjectFiles;
+    private List<User> users;
 
 }
 


### PR DESCRIPTION
Pretty straightforward addition. I added a command line argument to redact personal user info from the user object.

Kind of annoying that my eclipse reordered some imports. I can fix that if necessary but it should all be there.