### PR TITLE
Fix for Issue 39 - Masking initializer is no longer in sync with masking engine schema

### DIFF
--- a/generator/src/main/resources/endpointDefinitions/Application.yaml
+++ b/generator/src/main/resources/endpointDefinitions/Application.yaml
@@ -1,9 +1,11 @@
 className: [application]
 endpointPath: applications
 nameField: ApplicationName
-idField: ApplicationName
+idField: ApplicationId
 generatePut: false
 memberVariables:
+  - name: applicationId
+    type: Integer
   - name: applicationName
     type: String
   - name: environments

--- a/generator/src/main/resources/endpointDefinitions/Environment.yaml
+++ b/generator/src/main/resources/endpointDefinitions/Environment.yaml
@@ -9,8 +9,8 @@ memberVariables:
     type: Boolean
   - name: environmentId
     type: Integer
-  - name: application
-    type: String
+  - name: applicationId
+    type: Integer
   - name: purpose
     type: String
   - name: databaseConnectors

--- a/src/main/java/com/delphix/masking/initializer/maskingApi/BackupDriver.java
+++ b/src/main/java/com/delphix/masking/initializer/maskingApi/BackupDriver.java
@@ -468,7 +468,7 @@ public class BackupDriver {
         ArrayList<Environment> environments = new ArrayList<>();
         ArrayList<String> environmentFiles = new ArrayList<>();
         for (Environment environment : getEnvironments.getEnvironments()) {
-            if (environment.getApplication().equalsIgnoreCase(application.getApplicationName())) {
+            if (environment.getApplicationId().equals(application.getApplicationId())) {
 
                 if (scaled) {
                     Environment env = handleEnv(environment);

--- a/src/main/java/com/delphix/masking/initializer/maskingApi/SetupDriver.java
+++ b/src/main/java/com/delphix/masking/initializer/maskingApi/SetupDriver.java
@@ -394,18 +394,18 @@ public class SetupDriver {
                             JSON_EXTENSION);
                     logger.info("Reading from: " + envFilePath);
                     Environment environment = Utils.getClassFromFile(envFilePath, Environment.class);
-                    handleEnv(environment, application.getApplicationName());
+                    handleEnv(environment, application.getApplicationId());
                 }
             }
 
             if (application.getEnvironments() != null) {
-                handleEnvs(application.getEnvironments(), application.getApplicationName());
+                handleEnvs(application.getEnvironments(), application.getApplicationId());
             }
         }
     }
 
-    private void handleEnv(Environment environment, String appName) throws IOException, ApiCallException {
-        environment.setApplication(appName);
+    private void handleEnv(Environment environment, Integer appId) throws IOException, ApiCallException {
+        environment.setApplicationId(appId);
         PostEnvironment PostEnvironment = new PostEnvironment(environment);
         apiCallDriver.makePostCall(PostEnvironment);
         Integer envId = Integer.valueOf(PostEnvironment.getId());
@@ -420,9 +420,9 @@ public class SetupDriver {
         }
     }
 
-    private void handleEnvs(List<Environment> environments, String appName) throws IOException, ApiCallException {
+    private void handleEnvs(List<Environment> environments, Integer appId) throws IOException, ApiCallException {
         for (Environment environment : environments) {
-            handleEnv(environment, appName);
+            handleEnv(environment, appId);
         }
     }
 


### PR DESCRIPTION
**Background**
The delphix masking engine has changed its API specs for applications to use a sequential primary key instead of the application name. We need to make changes to how the masking-initializer consumes the masking engine to account for these changes. 

**Implementation**
Below, I've added a new field for application (ApplicationId) and adjusted the environment definition to reference application by ID. I then had to also modify `SetupDriver` and `BackupDriver` to correctly consume the new yaml schemas.

**Testing**
On a Delphix masking engine, I created an application and an environment. Before this change, running backup would cause an NPE. After applying these changes, I can run backup and see that the Yaml file is correctly created. I then deleted the environment and application and ran setup on the same engine. I then successfully observed that the engine was correctly set up with the application and environment.