### PR TITLE
Fix for issue delphix#51 - Compare engine version functionality is no…

### DIFF
--- a/src/main/java/com/delphix/masking/initializer/maskingApi/BackupDriver.java
+++ b/src/main/java/com/delphix/masking/initializer/maskingApi/BackupDriver.java
@@ -258,7 +258,12 @@ public class BackupDriver {
             apiCallDriver.makeGetCall(getSystemInformations);
             systemInformation = getSystemInformations.getSystemInformation();
         }
-        DefaultArtifactVersion engineVersion = new DefaultArtifactVersion(systemInformation.getVersion());
+        String version = systemInformation.getVersion();
+        // Some pre-release version may contain extra information after the version so ignore that.
+        if(version.contains("-")) {
+            version = version.substring(0, version.indexOf("-"));
+        }
+        DefaultArtifactVersion engineVersion = new DefaultArtifactVersion(version);
         DefaultArtifactVersion requiredEngineVersion = new DefaultArtifactVersion(requiredVersion);
         if (engineVersion.compareTo(requiredEngineVersion) >= 0) {
             return true;


### PR DESCRIPTION
…t working if the version contains additional string information.

Currently, Delphix release version always uses version format as x.x.x.x but 6.0/stage clone VM returning version like 6.0.1.0-snapshot.20200129214048590+jenkins-ops-devops-gate-master-appliance-build-6.0-stage-post-push-176

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
