### PR TITLE
Fix for issue #53 - Make changes in backup and restore for JDBC Drive…

### DIFF
--- a/generator/src/main/java/com/delphix/masking/endpointCodeGen/POJO/MemberVariable.java
+++ b/generator/src/main/java/com/delphix/masking/endpointCodeGen/POJO/MemberVariable.java
@@ -8,6 +8,7 @@ public class MemberVariable {
     private String name;
     private String type;
     private String listType;
+    private Boolean notResetToNull;
 
     public String getUpperName() {
         return name.substring(0, 1).toUpperCase() + name.substring(1);

--- a/generator/src/main/resources/endpointDefinitions/JdbcDriver.yaml
+++ b/generator/src/main/resources/endpointDefinitions/JdbcDriver.yaml
@@ -26,3 +26,6 @@ memberVariables:
     type: Boolean
   - name: fileReferenceId
     type: String
+  - name: pluginJvmPermissions
+    type: List
+    listType: JvmPermission

--- a/generator/src/main/resources/endpointDefinitions/JvmPermission.yaml
+++ b/generator/src/main/resources/endpointDefinitions/JvmPermission.yaml
@@ -1,0 +1,11 @@
+className: [Jvm, Permission]
+generateGet: false
+generatePut: false
+generatePost: false
+memberVariables:
+  - name: className
+    type: String
+  - name: target
+    type: String
+  - name: action
+    type: String

--- a/generator/src/main/resources/templates/CreateEndpoint.vm
+++ b/generator/src/main/resources/templates/CreateEndpoint.vm
@@ -63,7 +63,9 @@ public class Post${ClassName} extends PostApiCall {
 #foreach( $memberVariable in $memberVariables )
 #if ($memberVariable.listType)
         List<$memberVariable.listType> ${memberVariable.name} = ${className}.get${memberVariable.getUpperName()}();
-        ${className}.set${memberVariable.getUpperName()}(null);
+        #if (!$memberVariable.notResetToNull)
+                ${className}.set${memberVariable.getUpperName()}(null);
+        #end
 #end
 #end
 


### PR DESCRIPTION
…r's Permission

1- Currently, we are supporting backup and restore for JDBC Drivers but driver permissions are missing in both cases.So we need to make changes in backup and restore to support to backup and restore JDBC Driver's Permission.
2- Added new property in "memberVariables" which will default to false and should not impact the existing functionality.
Currency in autogenerated post classes we are setting the list type properties to null and handling those properties separately, which works for all cases but in case of JDBC Drivers, list property "pluginJvmPermissions" should be saved along with JDBC Drivers.
So now if we pass memberVariables=true it will not reset that list property to null.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
