### PR TITLE
#68 Update log4j to version 2.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ dependencies {
     compile group: 'org.apache.maven', name: 'maven-artifact', version: '3.0.3'
 
 
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.10.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.10.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.1'
 
     generatedSrc project(path: ':generator', configuration: 'classFiles')
     generateJar project(path: 'generator', configuration: 'jarOut')


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
Update log4j to version 2.17.1
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
# Solution:
Updated log4j to version 2.17.1
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
# Testing
Build:
```
Anils-MacBook-Pro:main-masking-initializer anilkumar$ ./gradlew dependencies 

> Task :dependencies 

------------------------------------------------------------
Root project
------------------------------------------------------------

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts.
No dependencies

compile - Dependencies for source set 'main' (deprecated, use 'implementation ' instead).
+--- com.google.code.gson:gson:2.8.0
+--- commons-io:commons-io:2.5
+--- org.yaml:snakeyaml:1.18
+--- org.apache.httpcomponents:httpclient:4.5.3
|    +--- org.apache.httpcomponents:httpcore:4.4.6
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.9
+--- org.apache.httpcomponents:httpmime:4.3.1
|    \--- org.apache.httpcomponents:httpclient:4.3.1 -> 4.5.3 (*)
+--- org.slf4j:slf4j-simple:1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
+--- commons-cli:commons-cli:1.4
+--- com.google.guava:guava:26.0-jre
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- org.checkerframework:checker-qual:2.5.2
|    +--- com.google.errorprone:error_prone_annotations:2.1.3
|    +--- com.google.j2objc:j2objc-annotations:1.1
|    \--- org.codehaus.mojo:animal-sniffer-annotations:1.14
+--- commons-lang:commons-lang:2.6
+--- org.apache.maven:maven-artifact:3.0.3
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
+--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.apache.logging.log4j:log4j-core:2.17.1
|    \--- org.apache.logging.log4j:log4j-api:2.17.1
\--- project :generator

compileClasspath - Compile classpath for source set 'main'.
+--- com.google.code.gson:gson:2.8.0
+--- commons-io:commons-io:2.5
+--- org.yaml:snakeyaml:1.18
+--- org.apache.httpcomponents:httpclient:4.5.3
|    +--- org.apache.httpcomponents:httpcore:4.4.6
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.9
+--- org.apache.httpcomponents:httpmime:4.3.1
|    \--- org.apache.httpcomponents:httpclient:4.3.1 -> 4.5.3 (*)
+--- org.slf4j:slf4j-simple:1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
+--- commons-cli:commons-cli:1.4
+--- com.google.guava:guava:26.0-jre
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- org.checkerframework:checker-qual:2.5.2
|    +--- com.google.errorprone:error_prone_annotations:2.1.3
|    +--- com.google.j2objc:j2objc-annotations:1.1
|    \--- org.codehaus.mojo:animal-sniffer-annotations:1.14
+--- commons-lang:commons-lang:2.6
+--- org.apache.maven:maven-artifact:3.0.3
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
+--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.apache.logging.log4j:log4j-core:2.17.1
|    \--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.projectlombok:lombok:1.16.16
\--- project :generator

compileOnly - Compile only dependencies for source set 'main'.
+--- org.projectlombok:lombok:1.16.16
\--- project :generator

default - Configuration for default artifacts.
+--- com.google.code.gson:gson:2.8.0
+--- commons-io:commons-io:2.5
+--- org.yaml:snakeyaml:1.18
+--- org.apache.httpcomponents:httpclient:4.5.3
|    +--- org.apache.httpcomponents:httpcore:4.4.6
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.9
+--- org.apache.httpcomponents:httpmime:4.3.1
|    \--- org.apache.httpcomponents:httpclient:4.3.1 -> 4.5.3 (*)
+--- org.slf4j:slf4j-simple:1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
+--- commons-cli:commons-cli:1.4
+--- com.google.guava:guava:26.0-jre
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- org.checkerframework:checker-qual:2.5.2
|    +--- com.google.errorprone:error_prone_annotations:2.1.3
|    +--- com.google.j2objc:j2objc-annotations:1.1
|    \--- org.codehaus.mojo:animal-sniffer-annotations:1.14
+--- commons-lang:commons-lang:2.6
+--- org.apache.maven:maven-artifact:3.0.3
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
+--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.apache.logging.log4j:log4j-core:2.17.1
|    \--- org.apache.logging.log4j:log4j-api:2.17.1
\--- project :generator

generateJar
\--- project :generator

generatedJar
No dependencies

generatedSrc
\--- project :generator

implementation - Implementation only dependencies for source set 'main'. (n)
No dependencies

runtime - Runtime dependencies for source set 'main' (deprecated, use 'runtimeOnly ' instead).
+--- com.google.code.gson:gson:2.8.0
+--- commons-io:commons-io:2.5
+--- org.yaml:snakeyaml:1.18
+--- org.apache.httpcomponents:httpclient:4.5.3
|    +--- org.apache.httpcomponents:httpcore:4.4.6
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.9
+--- org.apache.httpcomponents:httpmime:4.3.1
|    \--- org.apache.httpcomponents:httpclient:4.3.1 -> 4.5.3 (*)
+--- org.slf4j:slf4j-simple:1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
+--- commons-cli:commons-cli:1.4
+--- com.google.guava:guava:26.0-jre
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- org.checkerframework:checker-qual:2.5.2
|    +--- com.google.errorprone:error_prone_annotations:2.1.3
|    +--- com.google.j2objc:j2objc-annotations:1.1
|    \--- org.codehaus.mojo:animal-sniffer-annotations:1.14
+--- commons-lang:commons-lang:2.6
+--- org.apache.maven:maven-artifact:3.0.3
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
+--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.apache.logging.log4j:log4j-core:2.17.1
|    \--- org.apache.logging.log4j:log4j-api:2.17.1
\--- project :generator

runtimeClasspath - Runtime classpath of source set 'main'.
+--- com.google.code.gson:gson:2.8.0
+--- commons-io:commons-io:2.5
+--- org.yaml:snakeyaml:1.18
+--- org.apache.httpcomponents:httpclient:4.5.3
|    +--- org.apache.httpcomponents:httpcore:4.4.6
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.9
+--- org.apache.httpcomponents:httpmime:4.3.1
|    \--- org.apache.httpcomponents:httpclient:4.3.1 -> 4.5.3 (*)
+--- org.slf4j:slf4j-simple:1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
+--- commons-cli:commons-cli:1.4
+--- com.google.guava:guava:26.0-jre
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- org.checkerframework:checker-qual:2.5.2
|    +--- com.google.errorprone:error_prone_annotations:2.1.3
|    +--- com.google.j2objc:j2objc-annotations:1.1
|    \--- org.codehaus.mojo:animal-sniffer-annotations:1.14
+--- commons-lang:commons-lang:2.6
+--- org.apache.maven:maven-artifact:3.0.3
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
+--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.apache.logging.log4j:log4j-core:2.17.1
|    \--- org.apache.logging.log4j:log4j-api:2.17.1
\--- project :generator

runtimeElements - Elements of runtime for main. (n)
No dependencies

runtimeOnly - Runtime only dependencies for source set 'main'. (n)
No dependencies

testCompile - Dependencies for source set 'test' (deprecated, use 'testImplementation ' instead).
+--- com.google.code.gson:gson:2.8.0
+--- commons-io:commons-io:2.5
+--- org.yaml:snakeyaml:1.18
+--- org.apache.httpcomponents:httpclient:4.5.3
|    +--- org.apache.httpcomponents:httpcore:4.4.6
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.9
+--- org.apache.httpcomponents:httpmime:4.3.1
|    \--- org.apache.httpcomponents:httpclient:4.3.1 -> 4.5.3 (*)
+--- org.slf4j:slf4j-simple:1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
+--- commons-cli:commons-cli:1.4
+--- com.google.guava:guava:26.0-jre
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- org.checkerframework:checker-qual:2.5.2
|    +--- com.google.errorprone:error_prone_annotations:2.1.3
|    +--- com.google.j2objc:j2objc-annotations:1.1
|    \--- org.codehaus.mojo:animal-sniffer-annotations:1.14
+--- commons-lang:commons-lang:2.6
+--- org.apache.maven:maven-artifact:3.0.3
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
+--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.apache.logging.log4j:log4j-core:2.17.1
|    \--- org.apache.logging.log4j:log4j-api:2.17.1
+--- project :generator
+--- com.google.truth:truth:0.31
|    +--- com.google.guava:guava:20.0 -> 26.0-jre (*)
|    +--- junit:junit:4.10 -> 4.12
|    |    \--- org.hamcrest:hamcrest-core:1.3
|    \--- com.google.errorprone:error_prone_annotations:2.0.12 -> 2.1.3
+--- junit:junit:4.12 (*)
+--- com.palantir.docker.compose:docker-compose-rule-junit4:0.32.0 FAILED
\--- org.postgresql:postgresql:42.1.4

testCompileClasspath - Compile classpath for source set 'test'.
+--- com.google.code.gson:gson:2.8.0
+--- commons-io:commons-io:2.5
+--- org.yaml:snakeyaml:1.18
+--- org.apache.httpcomponents:httpclient:4.5.3
|    +--- org.apache.httpcomponents:httpcore:4.4.6
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.9
+--- org.apache.httpcomponents:httpmime:4.3.1
|    \--- org.apache.httpcomponents:httpclient:4.3.1 -> 4.5.3 (*)
+--- org.slf4j:slf4j-simple:1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
+--- commons-cli:commons-cli:1.4
+--- com.google.guava:guava:26.0-jre
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- org.checkerframework:checker-qual:2.5.2
|    +--- com.google.errorprone:error_prone_annotations:2.1.3
|    +--- com.google.j2objc:j2objc-annotations:1.1
|    \--- org.codehaus.mojo:animal-sniffer-annotations:1.14
+--- commons-lang:commons-lang:2.6
+--- org.apache.maven:maven-artifact:3.0.3
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
+--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.apache.logging.log4j:log4j-core:2.17.1
|    \--- org.apache.logging.log4j:log4j-api:2.17.1
+--- project :generator
+--- com.google.truth:truth:0.31
|    +--- com.google.guava:guava:20.0 -> 26.0-jre (*)
|    +--- junit:junit:4.10 -> 4.12
|    |    \--- org.hamcrest:hamcrest-core:1.3
|    \--- com.google.errorprone:error_prone_annotations:2.0.12 -> 2.1.3
+--- junit:junit:4.12 (*)
+--- com.palantir.docker.compose:docker-compose-rule-junit4:0.32.0 FAILED
\--- org.postgresql:postgresql:42.1.4

testCompileOnly - Compile only dependencies for source set 'test'.
No dependencies

testImplementation - Implementation only dependencies for source set 'test'. (n)
No dependencies

testRuntime - Runtime dependencies for source set 'test' (deprecated, use 'testRuntimeOnly ' instead).
+--- com.google.code.gson:gson:2.8.0
+--- commons-io:commons-io:2.5
+--- org.yaml:snakeyaml:1.18
+--- org.apache.httpcomponents:httpclient:4.5.3
|    +--- org.apache.httpcomponents:httpcore:4.4.6
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.9
+--- org.apache.httpcomponents:httpmime:4.3.1
|    \--- org.apache.httpcomponents:httpclient:4.3.1 -> 4.5.3 (*)
+--- org.slf4j:slf4j-simple:1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
+--- commons-cli:commons-cli:1.4
+--- com.google.guava:guava:26.0-jre
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- org.checkerframework:checker-qual:2.5.2
|    +--- com.google.errorprone:error_prone_annotations:2.1.3
|    +--- com.google.j2objc:j2objc-annotations:1.1
|    \--- org.codehaus.mojo:animal-sniffer-annotations:1.14
+--- commons-lang:commons-lang:2.6
+--- org.apache.maven:maven-artifact:3.0.3
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
+--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.apache.logging.log4j:log4j-core:2.17.1
|    \--- org.apache.logging.log4j:log4j-api:2.17.1
+--- project :generator
+--- com.google.truth:truth:0.31
|    +--- com.google.guava:guava:20.0 -> 26.0-jre (*)
|    +--- junit:junit:4.10 -> 4.12
|    |    \--- org.hamcrest:hamcrest-core:1.3
|    \--- com.google.errorprone:error_prone_annotations:2.0.12 -> 2.1.3
+--- junit:junit:4.12 (*)
+--- com.palantir.docker.compose:docker-compose-rule-junit4:0.32.0 FAILED
\--- org.postgresql:postgresql:42.1.4

testRuntimeClasspath - Runtime classpath of source set 'test'.
+--- com.google.code.gson:gson:2.8.0
+--- commons-io:commons-io:2.5
+--- org.yaml:snakeyaml:1.18
+--- org.apache.httpcomponents:httpclient:4.5.3
|    +--- org.apache.httpcomponents:httpcore:4.4.6
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.9
+--- org.apache.httpcomponents:httpmime:4.3.1
|    \--- org.apache.httpcomponents:httpclient:4.3.1 -> 4.5.3 (*)
+--- org.slf4j:slf4j-simple:1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
+--- commons-cli:commons-cli:1.4
+--- com.google.guava:guava:26.0-jre
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- org.checkerframework:checker-qual:2.5.2
|    +--- com.google.errorprone:error_prone_annotations:2.1.3
|    +--- com.google.j2objc:j2objc-annotations:1.1
|    \--- org.codehaus.mojo:animal-sniffer-annotations:1.14
+--- commons-lang:commons-lang:2.6
+--- org.apache.maven:maven-artifact:3.0.3
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
+--- org.apache.logging.log4j:log4j-api:2.17.1
+--- org.apache.logging.log4j:log4j-core:2.17.1
|    \--- org.apache.logging.log4j:log4j-api:2.17.1
+--- project :generator
+--- com.google.truth:truth:0.31
|    +--- com.google.guava:guava:20.0 -> 26.0-jre (*)
|    +--- junit:junit:4.10 -> 4.12
|    |    \--- org.hamcrest:hamcrest-core:1.3
|    \--- com.google.errorprone:error_prone_annotations:2.0.12 -> 2.1.3
+--- junit:junit:4.12 (*)
+--- com.palantir.docker.compose:docker-compose-rule-junit4:0.32.0 FAILED
\--- org.postgresql:postgresql:42.1.4

testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
No dependencies

(*) - dependencies omitted (listed previously)


BUILD SUCCESSFUL in 3s
1 actionable task: 1 executed
Anils-MacBook-Pro:main-masking-initializer anilkumar$ 

```
Backup:
```
$ ./dlpx-masking-initializer -f /Users/anilkumar/backup.yaml -H 10.119.138.65 -p 80 -u admin -P Admin-12 -b
11:43:59.215 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/login](http://10.119.138.65/masking/api/login) POST
11:44:01.079 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/file-formats?page_size=1000&&page_number=1](http://10.119.138.65/masking/api/file-formats?page_size=1000&&page_number=1) GET
11:44:01.746 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/system-information](http://10.119.138.65/masking/api/system-information) GET
11:44:02.381 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/jdbc-drivers?is_built_in=false](http://10.119.138.65/masking/api/jdbc-drivers?is_built_in=false) GET
11:44:03.003 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/mount-filesystem?page_size=1000&&page_number=1](http://10.119.138.65/masking/api/mount-filesystem?page_size=1000&&page_number=1) GET
11:44:03.619 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/profile-sets?page_size=1000&&page_number=1](http://10.119.138.65/masking/api/profile-sets?page_size=1000&&page_number=1) GET
11:44:04.938 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/applications?page_size=1000&&page_number=1](http://10.119.138.65/masking/api/applications?page_size=1000&&page_number=1) GET
11:44:05.578 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/file-connectors?page_size=1000&&page_number=1](http://10.119.138.65/masking/api/file-connectors?page_size=1000&&page_number=1) GET
11:44:06.200 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/file-rulesets?page_size=1000&&page_number=1](http://10.119.138.65/masking/api/file-rulesets?page_size=1000&&page_number=1) GET
11:44:06.819 [main] INFO  com.delphix.masking.initializer.maskingApi.endpointCaller.ApiCallDriver - [http://10.119.138.65:80/masking/api/file-metadata?page_size=1000&&page_number=1](http://10.119.138.65/masking/api/file-metadata?page_size=1000&&page_number=1) GET
```
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
